### PR TITLE
fixup! [Endless] Create /lib/firmware/updates as a link to /var/lib/firmware

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -60,7 +60,7 @@ binary-indep: install-indep
 	dh_link -i
 	dh_installchangelogs -i
 	dh_installdocs -i
-	dh_install -i --fail-missing
+	dh_missing --fail-missing
 	dh_compress -i
 	dh_fixperms -i
 	dh_installdeb -i


### PR DESCRIPTION
"dh_install -i --fail-missing" was removed in compat 12.
Use "dh_missing --fail-missing" instead.

https://phabricator.endlessm.com/T31252