### PR TITLE
[Endless] Depend on firmware-sof-signed

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,7 @@ Package: linux-firmware
 Architecture: all
 Multi-Arch: foreign
 Priority: optional
-Depends: ${misc:Depends}
-Recommends: firmware-sof-signed
+Depends: ${misc:Depends}, firmware-sof-signed
 Provides: atmel-firmware
 Conflicts: atmel-firmware
 Replaces: atmel-firmware, linux-restricted-common, linux-firmware-snapdragon (<= 1.2-0ubuntu1)


### PR DESCRIPTION
The commit ("UBUNTU: [Packaging] Downgrade firmware-sof-signed depends
to recommends") make firmware-sof-signed into Recommends dependency,
which leads EOS miss firmware-sof-signed, then have no Intel SoF related
firmware files.

This commit makes linux-firmware depends on firmware-sof-signed again.

https://phabricator.endlessm.com/T33236#930671